### PR TITLE
Fix response format type validation error

### DIFF
--- a/euraika-code/backend/app/domain/services/agents/execution.py
+++ b/euraika-code/backend/app/domain/services/agents/execution.py
@@ -41,7 +41,7 @@ class ExecutionAgent(BaseAgent):
 
     name: str = "execution"
     system_prompt: str = SYSTEM_PROMPT + EXECUTION_SYSTEM_PROMPT
-    format: str = "json_object"
+    format: str = None
 
     def __init__(
         self,

--- a/euraika-code/backend/app/domain/services/agents/planner.py
+++ b/euraika-code/backend/app/domain/services/agents/planner.py
@@ -36,7 +36,7 @@ class PlannerAgent(BaseAgent):
 
     name: str = "planner"
     system_prompt: str = SYSTEM_PROMPT + PLANNER_SYSTEM_PROMPT
-    format: Optional[str] = "json_object"
+    format: Optional[str] = None
     tool_choice: Optional[str] = "none"
 
     def __init__(

--- a/euraika-code/backend/app/infrastructure/utils/llm_json_parser.py
+++ b/euraika-code/backend/app/infrastructure/utils/llm_json_parser.py
@@ -180,8 +180,7 @@ JSON:"""
         
         try:
             response = await self.llm.ask(
-                messages=messages,
-                response_format={"type": "json_object"}
+                messages=messages
             )
             
             content = response.get("content", "").strip()


### PR DESCRIPTION
The OpenAI-compatible API being used only accepts 'json_schema' or 'text' as valid response_format types. The old 'json_object' format is no longer supported and was causing a 400 error.

Changes:
- Set format to None in planner.py (line 39)
- Set format to None in execution.py (line 44)
- Removed response_format parameter from llm_json_parser.py (line 184)

This allows the API to use its default text response format, and the existing LLMJsonParser will handle extracting JSON from the text responses.

## Summary by Sourcery

Remove unsupported 'json_object' response format to prevent 400 errors and allow default text responses to be parsed.

Bug Fixes:
- Unset the format attribute in PlannerAgent and ExecutionAgent instead of using "json_object"
- Remove the response_format parameter from LLM calls in llm_json_parser to rely on default text format for JSON extraction